### PR TITLE
Fix bug with missing-reference in docflow link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docflow/ckeditor5-build-docflow",
-  "version": "1.4.2",
+  "version": "1.4.4",
   "description": "Docflow build of CKEditor 5",
   "main": "./build/ckeditor.js",
   "files": [

--- a/src/plugins/docflow-link/docflow-link-editing.js
+++ b/src/plugins/docflow-link/docflow-link-editing.js
@@ -123,7 +123,7 @@ export default class DocflowLinkEditing extends Plugin {
 			.elementToElement( {
 				view: {
 					name: 'span',
-					class: 'missing-reference'
+					classes: [ 'missing-reference' ]
 				},
 				model: ( viewElement, modelWriter ) => {
 					let name = '';


### PR DESCRIPTION
Fixed bug. `class` is not a valid configuration. Changed it to `classes`.

Bumped version from `1.4.2` to `1.4.4` because version `1.4.3` was the latest published version in NPM.