### PR TITLE
chore: fix the deploy script

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,7 +48,7 @@ jobs:
 
             exec.exec(`npm version ${newPackageVersion} --no-git-tag-version --allow-same-version`);
       - name: Build
-        run: NODE_OPTIONS=--openssl-legacy-provider npm run build
+        run: npm run build
 
       - name: Publish
         env:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,7 +46,7 @@ jobs:
             }
             const newPackageVersion = `${major}.${minor}.${patch}`;
 
-            exec.exec(`npm version ${newPackageVersion} --no-git-tag-version`);
+            exec.exec(`npm version ${newPackageVersion} --no-git-tag-version --allow-same-version`);
       - name: Build
         run: NODE_OPTIONS=--openssl-legacy-provider npm run build
 

--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
   "scripts": {
     "build": "tsc -p ./jsconfig.json & webpack --mode production",
     "lint": "eslint './src/**/*.js'",
-    "watch": "webpack --mode development --watch --info-verbosity verbose",
-    "preversion": "npm run build; if [ -n \"$(git status src/ckeditor.js build/ --porcelain)\" ]; then git add -u src/ckeditor.js build/ && git commit -m 'Internal: Build.'; fi"
+    "watch": "webpack --mode development --watch --info-verbosity verbose"
   },
   "prettier": {
     "trailingComma": "all"


### PR DESCRIPTION
The previous deploy of version 2.0.0 failed because I wrote that version in the package.json, so I'm gonna mark this commit as containing breaking changes even though it's the previous commit that has them