### PR TITLE
chore: fix publish script

### DIFF
--- a/.github/scripts/bump-version.js
+++ b/.github/scripts/bump-version.js
@@ -6,13 +6,13 @@ async function bumpPackageVersion(packageJson, { exec, context }) {
   const npmRegistryUrl = "https://registry.npmjs.org";
 
   const currentPackageVersion = await fetch(
-    `${npmRegistryUrl}/${packageJson.name}`
+    `${npmRegistryUrl}/${packageJson.name}`,
   )
     .then(async (res) => (await res.json()).versions)
     .then((versions) =>
       Object.keys(versions)
         .sort((a, b) => a.localeCompare(b))
-        .pop()
+        .pop(),
     );
 
   if (currentPackageVersion !== undefined) {
@@ -20,7 +20,10 @@ async function bumpPackageVersion(packageJson, { exec, context }) {
     let [major, minor, patch] = currentPackageVersion
       .split(".")
       .map((v) => parseInt(v, 10));
-    if (commitMessage.includes("BREAKING CHANGE") || commitMessage.includes("!:")) {
+    if (
+      commitMessage.includes("BREAKING CHANGE") ||
+      commitMessage.includes("!:")
+    ) {
       major++;
       minor = 0;
       patch = 0;
@@ -33,7 +36,7 @@ async function bumpPackageVersion(packageJson, { exec, context }) {
     const newPackageVersion = `${major}.${minor}.${patch}`;
 
     exec.exec(
-      `npm version ${newPackageVersion} --no-git-tag-version --allow-same-version`
+      `npm version ${newPackageVersion} --no-git-tag-version --allow-same-version`,
     );
   }
 }

--- a/.github/scripts/bump-version.js
+++ b/.github/scripts/bump-version.js
@@ -1,0 +1,41 @@
+/**
+ * @param {Record<string, unknown>} packageJson
+ * @param {{ exec: typeof exec; context: typeof context; }} params
+ */
+async function bumpPackageVersion(packageJson, { exec, context }) {
+  const npmRegistryUrl = "https://registry.npmjs.org";
+
+  const currentPackageVersion = await fetch(
+    `${npmRegistryUrl}/${packageJson.name}`
+  )
+    .then(async (res) => (await res.json()).versions)
+    .then((versions) =>
+      Object.keys(versions)
+        .sort((a, b) => a.localeCompare(b))
+        .pop()
+    );
+
+  if (currentPackageVersion !== undefined) {
+    const commitMessage = context.payload.head_commit.message;
+    let [major, minor, patch] = currentPackageVersion
+      .split(".")
+      .map((v) => parseInt(v, 10));
+    if (commitMessage.includes("BREAKING CHANGE") || commitMessage.includes("!:")) {
+      major++;
+      minor = 0;
+      patch = 0;
+    } else if (commitMessage.toLowerCase().startsWith("feat")) {
+      minor++;
+      patch = 0;
+    } else {
+      patch++;
+    }
+    const newPackageVersion = `${major}.${minor}.${patch}`;
+
+    exec.exec(
+      `npm version ${newPackageVersion} --no-git-tag-version --allow-same-version`
+    );
+  }
+}
+
+module.exports = { bumpPackageVersion };

--- a/.github/scripts/globals.d.ts
+++ b/.github/scripts/globals.d.ts
@@ -1,0 +1,2 @@
+declare const context: import("@actions/github/lib/context").Context;
+declare const exec: typeof import("@actions/exec");

--- a/.github/scripts/jsconfig.json
+++ b/.github/scripts/jsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ES2020",
+    "jsx": "react",
+    "strict": true,
+    "checkJs": true,
+    "skipLibCheck": false,
+    "types": ["./globals", "node"]
+  },
+  "exclude": ["node_modules", "**/node_modules/*"]
+}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,6 +8,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip release]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,26 +32,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           script: |
-            const packageJson = require('./package.json');
-            const npmRegistryUrl = 'https://registry.npmjs.org';
-
-            const currentPackageVersion = await fetch(`${npmRegistryUrl}/${packageJson.name}/latest`).then(async (res) => (await res.json()).version);
-
-            const commitMessage = context.payload.head_commit.message;
-            let [major, minor, patch] = currentPackageVersion.split('.').map(v => parseInt(v, 10));
-            if (commitMessage.includes('BREAKING CHANGE') || commitMessage.includes('!:')) {
-              major++;
-              minor = 0;
-              patch = 0;
-            } else if (commitMessage.toLowerCase().startsWith('feat')) {
-              minor++;
-              patch = 0;
-            } else {
-              patch++;
-            }
-            const newPackageVersion = `${major}.${minor}.${patch}`;
-
-            exec.exec(`npm version ${newPackageVersion} --no-git-tag-version --allow-same-version`);
+            const packageJson = require("./package.json");
+            const script = require('.github/scripts/bump-version');
+            await script.bumpPackageVersion(packageJson, { context, exec });
       - name: Build
         run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build"
   ],
   "devDependencies": {
+    "@actions/exec": "^1.1.1",
+    "@actions/github": "^6.0.0",
     "@babel/core": "^7.23.6",
     "@babel/plugin-proposal-object-rest-spread": "^7.9.0",
     "@babel/plugin-transform-runtime": "^7.23.6",
@@ -36,6 +38,7 @@
     "@ckeditor/ckeditor5-utils": "^40.2.0",
     "@ckeditor/ckeditor5-widget": "^40.2.0",
     "@rails/activestorage": "^7.1.2",
+    "@types/node": "^20.10.4",
     "@types/rails__activestorage": "^7.1.1",
     "babel-loader": "^9.1.3",
     "css-loader": "^6.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 devDependencies:
+  '@actions/exec':
+    specifier: ^1.1.1
+    version: 1.1.1
+  '@actions/github':
+    specifier: ^6.0.0
+    version: 6.0.0
   '@babel/core':
     specifier: ^7.23.6
     version: 7.23.6
@@ -89,6 +95,9 @@ devDependencies:
   '@rails/activestorage':
     specifier: ^7.1.2
     version: 7.1.2
+  '@types/node':
+    specifier: ^20.10.4
+    version: 20.10.4
   '@types/rails__activestorage':
     specifier: ^7.1.1
     version: 7.1.1
@@ -149,6 +158,32 @@ packages:
   /@aashutoshrathi/word-wrap@1.2.6:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /@actions/exec@1.1.1:
+    resolution: {integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==}
+    dependencies:
+      '@actions/io': 1.1.3
+    dev: true
+
+  /@actions/github@6.0.0:
+    resolution: {integrity: sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==}
+    dependencies:
+      '@actions/http-client': 2.2.0
+      '@octokit/core': 5.0.2
+      '@octokit/plugin-paginate-rest': 9.1.5(@octokit/core@5.0.2)
+      '@octokit/plugin-rest-endpoint-methods': 10.2.0(@octokit/core@5.0.2)
+    dev: true
+
+  /@actions/http-client@2.2.0:
+    resolution: {integrity: sha512-q+epW0trjVUUHboliPb4UF9g2msf+w61b32tAkFEwL/IwP0DQWgbCMM0Hbe3e3WXSKz5VcUXbzJQgy8Hkra/Lg==}
+    dependencies:
+      tunnel: 0.0.6
+      undici: 5.28.2
+    dev: true
+
+  /@actions/io@1.1.3:
+    resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
     dev: true
 
   /@ampproject/remapping@2.2.1:
@@ -1913,6 +1948,11 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@fastify/busboy@2.1.0:
+    resolution: {integrity: sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==}
+    engines: {node: '>=14'}
+    dev: true
+
   /@gar/promisify@1.1.3:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
     dev: true
@@ -2018,6 +2058,90 @@ packages:
       rimraf: 3.0.2
     dev: true
 
+  /@octokit/auth-token@4.0.0:
+    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
+    engines: {node: '>= 18'}
+    dev: true
+
+  /@octokit/core@5.0.2:
+    resolution: {integrity: sha512-cZUy1gUvd4vttMic7C0lwPed8IYXWYp8kHIMatyhY8t8n3Cpw2ILczkV5pGMPqef7v0bLo0pOHrEHarsau2Ydg==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/auth-token': 4.0.0
+      '@octokit/graphql': 7.0.2
+      '@octokit/request': 8.1.6
+      '@octokit/request-error': 5.0.1
+      '@octokit/types': 12.4.0
+      before-after-hook: 2.2.3
+      universal-user-agent: 6.0.1
+    dev: true
+
+  /@octokit/endpoint@9.0.4:
+    resolution: {integrity: sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/types': 12.4.0
+      universal-user-agent: 6.0.1
+    dev: true
+
+  /@octokit/graphql@7.0.2:
+    resolution: {integrity: sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/request': 8.1.6
+      '@octokit/types': 12.4.0
+      universal-user-agent: 6.0.1
+    dev: true
+
+  /@octokit/openapi-types@19.1.0:
+    resolution: {integrity: sha512-6G+ywGClliGQwRsjvqVYpklIfa7oRPA0vyhPQG/1Feh+B+wU0vGH1JiJ5T25d3g1JZYBHzR2qefLi9x8Gt+cpw==}
+    dev: true
+
+  /@octokit/plugin-paginate-rest@9.1.5(@octokit/core@5.0.2):
+    resolution: {integrity: sha512-WKTQXxK+bu49qzwv4qKbMMRXej1DU2gq017euWyKVudA6MldaSSQuxtz+vGbhxV4CjxpUxjZu6rM2wfc1FiWVg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=5'
+    dependencies:
+      '@octokit/core': 5.0.2
+      '@octokit/types': 12.4.0
+    dev: true
+
+  /@octokit/plugin-rest-endpoint-methods@10.2.0(@octokit/core@5.0.2):
+    resolution: {integrity: sha512-ePbgBMYtGoRNXDyKGvr9cyHjQ163PbwD0y1MkDJCpkO2YH4OeXX40c4wYHKikHGZcpGPbcRLuy0unPUuafco8Q==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=5'
+    dependencies:
+      '@octokit/core': 5.0.2
+      '@octokit/types': 12.4.0
+    dev: true
+
+  /@octokit/request-error@5.0.1:
+    resolution: {integrity: sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/types': 12.4.0
+      deprecation: 2.3.1
+      once: 1.4.0
+    dev: true
+
+  /@octokit/request@8.1.6:
+    resolution: {integrity: sha512-YhPaGml3ncZC1NfXpP3WZ7iliL1ap6tLkAp6MvbK2fTTPytzVUyUesBBogcdMm86uRYO5rHaM1xIWxigWZ17MQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/endpoint': 9.0.4
+      '@octokit/request-error': 5.0.1
+      '@octokit/types': 12.4.0
+      universal-user-agent: 6.0.1
+    dev: true
+
+  /@octokit/types@12.4.0:
+    resolution: {integrity: sha512-FLWs/AvZllw/AGVs+nJ+ELCDZZJk+kY0zMen118xhL2zD0s1etIUHm1odgjP7epxYU1ln7SZxEUWYop5bhsdgQ==}
+    dependencies:
+      '@octokit/openapi-types': 19.1.0
+    dev: true
+
   /@rails/activestorage@7.1.2:
     resolution: {integrity: sha512-evC/xGlpq5XGpcNJina3oNVVB8pUp1GpnN3a84SVA+UNuB6O91OdNRl9BGHNAOo6/jxmFtLb73PIjWqQyVE14w==}
     dependencies:
@@ -2070,10 +2194,6 @@ packages:
     resolution: {integrity: sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==}
     dependencies:
       undici-types: 5.26.5
-    dev: true
-
-  /@types/node@20.8.2:
-    resolution: {integrity: sha512-Vvycsc9FQdwhxE3y3DzeIxuEJbWGDsnrxvMADzTDF/lcdR9/K+AQIeAghTQsHtotg/q0j3WEOYS/jQgSdWue3w==}
     dev: true
 
   /@types/parse-json@4.0.2:
@@ -2582,6 +2702,10 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
 
+  /before-after-hook@2.2.3:
+    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+    dev: true
+
   /big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
     dev: true
@@ -3047,6 +3171,10 @@ packages:
       p-map: 3.0.0
       rimraf: 3.0.2
       slash: 3.0.0
+    dev: true
+
+  /deprecation@2.3.1:
+    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
     dev: true
 
   /dir-glob@3.0.1:
@@ -3753,7 +3881,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.8.2
+      '@types/node': 20.10.4
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -5247,6 +5375,11 @@ packages:
       typescript: 5.3.3
     dev: true
 
+  /tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+    dev: true
+
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -5273,6 +5406,13 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: true
+
+  /undici@5.28.2:
+    resolution: {integrity: sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==}
+    engines: {node: '>=14.0'}
+    dependencies:
+      '@fastify/busboy': 2.1.0
     dev: true
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
@@ -5308,6 +5448,10 @@ packages:
     resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
     dependencies:
       imurmurhash: 0.1.4
+    dev: true
+
+  /universal-user-agent@6.0.1:
+    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
     dev: true
 
   /universalify@2.0.1:


### PR DESCRIPTION
Extracts it into a separate file with formatting and type-checking, handles the prerelease versions correctly and adds support for `[skip release]`