### PR TITLE
feat: change colors in table properties to hex

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -40,6 +40,7 @@ import DocfieldImageUpload from "./plugins/docfield-image-upload/docfield-image-
 import DocfieldComments from "./plugins/docfield-comments/docfield-comments";
 import DocfieldSmartfield from "./plugins/docfield-smartfield/docfield-smartfield";
 import "./ckeditor.css";
+import { defaultColorsHex } from "./constants";
 
 const plugins = [
   Essentials,
@@ -118,6 +119,20 @@ const config = {
       "tableProperties",
       "tableCellProperties",
     ],
+    tableProperties: {
+      colorPicker: {
+        format: "hex",
+      },
+      backgroundColors: defaultColorsHex,
+      borderColors: defaultColorsHex,
+    },
+    tableCellProperties: {
+      colorPicker: {
+        format: "hex",
+      },
+      backgroundColors: defaultColorsHex,
+      borderColors: defaultColorsHex,
+    },
   },
   list: {
     properties: {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,67 @@
+// Default CKEditor colors in hex format
+// It's a conversion of the defaultColors from the CKEditor 5 source code
+// https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-table/src/utils/ui/table-properties.ts
+
+export const defaultColorsHex = [
+  {
+    color: "#000000",
+    label: "Black",
+  },
+  {
+    color: "#4d4d4d",
+    label: "Dim grey",
+  },
+  {
+    color: "#999999",
+    label: "Grey",
+  },
+  {
+    color: "#e6e6e6",
+    label: "Light grey",
+  },
+  {
+    color: "#ffffff",
+    label: "White",
+    hasBorder: true,
+  },
+  {
+    color: "#e64c4c",
+    label: "Red",
+  },
+  {
+    color: "#e6994c",
+    label: "Orange",
+  },
+  {
+    color: "#e6e64c",
+    label: "Yellow",
+  },
+  {
+    color: "#99e64c",
+    label: "Light green",
+  },
+  {
+    color: "#4ce64c",
+    label: "Green",
+  },
+  {
+    color: "#4ce699",
+    label: "Aquamarine",
+  },
+  {
+    color: "#4ce6e6",
+    label: "Turquoise",
+  },
+  {
+    color: "#4c99e6",
+    label: "Light blue",
+  },
+  {
+    color: "#4c4ce6",
+    label: "Blue",
+  },
+  {
+    color: "#994ce6",
+    label: "Purple",
+  },
+];


### PR DESCRIPTION
HSL colors in table properties are not supported by mpdf (https://github.com/mpdf/mpdf/issues/1864)